### PR TITLE
issue #1992: flatListWithRoot description

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,14 @@ sidebar_label: API Changelog
 
 ⚠ Consider subscribing to our [**API Newsletter**](http://eepurl.com/g2EiC1) to be notified about upcoming API changes in the future.
 
+## Version 1.5
+
+The following changes to the API are scheduled to be deployed in **calendar week 33**. As all of these changes are **New** additions to existing behavior, there should be no action required by Developers. The impacted documentation pages and swagger specifications have already been updated accordingly.
+
+### New: `flatListWithRoot` Inbox Right Sidebar tree builder
+
+A new type of tree builder is available for the Inbox Right Sidebar - `flatListWithRoot`. This tree builder builds a flat list of Tickets using common Root Ticket. The Root Ticket is included in the list and have some action buttons in the UI. More information can be found on [Manifest API](general/manifest-api#inboxrightsidebar) page.
+
 ## Version 1.4
 
 The following changes to the API are scheduled to be deployed in **calendar week 31**. As all of these changes are **New** additions to existing behavior, there should be no action required by Developers. The impacted documentation pages and swagger specifications have already been updated accordingly.

--- a/docs/general/manifest-api.md
+++ b/docs/general/manifest-api.md
@@ -96,9 +96,12 @@ curl -X PATCH "https://api.socialhub.io/manifest?accesstoken=eyJhbGciOiJIUzI1NiI
 |-----------------|--------------------------------------------------------------|
 | `id`            | String identifier for this sidebar Tab. |
 | `label`         | Human readable label to display for the sidebar Tab. |
-| `treeBuilder`   | The tree-builder algorithm to use. Currently only `flatListWithoutRoot` is supported. |
+| `treeBuilder`   | The tree-builder algorithm to use. Currently only `flatListWithoutRoot` and `flatListWithRoot` are supported. |
 
-The `flatListWithoutRoot` tree builder simply displays all Tickets in the right sidebar that share the same Root-Ticket.
+The `flatListWithoutRoot` tree builder simply displays all Tickets in the right sidebar that share the same Root-Ticket excluding the Root-Ticket itself.
+
+`flatListWithRoot` tree builder displays all Tickets with the same Root-Ticket including the Root-Ticket.
+Root-Ticket in the sidebar will have some additional actions like `Show unread Tickets in the Inbox`.
 
 #### `callbacks`
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -507,7 +507,7 @@ definitions:
                 treeBuilder:
                   type: string
                   description: 'The tree-builder algorithm to use.'
-                  enum: ['flatListWithoutRoot']
+                  enum: ['flatListWithoutRoot', 'flatListWithRoot']
               required:
                 - id
                 - label


### PR DESCRIPTION
PR updates the swagger schema and adds description for `flatListWithRoot` tree builder