### PR TITLE
shcomp#2212: Added information about Ticket Action attachments field.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,14 @@ sidebar_label: API Changelog
 
 ⚠ Consider subscribing to our [**API Newsletter**](http://eepurl.com/g2EiC1) to be notified about upcoming API changes in the future.
 
+## Version 1.7
+
+The following changes to the API are scheduled to be deployed in **calendar week 46**. As all of these changes are **New** additions to existing behavior, there should be no action required by Developers. The impacted documentation pages and swagger specifications have already been updated accordingly.
+
+### New: Reply Attachments
+
+It's now possible that a Ticket Action of type `reply` may have attachments. To control whether it's possible to specify attachments for a Reply simply set `attachments: {}` on the Ticket Action definition in the [Manifest](general/manifest-api#request). At a later point you'll be able to specify a file schema to control what kind of attachments are allowed – for now there is no restriction an all checks should happen on the Integration's end.
+
 ## Version 1.6
 
 The following changes to the API are scheduled to be deployed in **calendar week 36**. Note that some of these changes are breaking previous behavior. The impacted documentation pages and swagger specifications have already been updated accordingly.

--- a/docs/general/manifest-api.md
+++ b/docs/general/manifest-api.md
@@ -83,6 +83,7 @@ curl -X PATCH "https://api.socialhub.io/manifest?accesstoken=eyJhbGciOiJIUzI1NiI
 | `id`            | Identifier of the Action. Each Action within a manifest must have a different identifier. Pattern regular expression: `^[a-zA-Z0-9-_]{1,256}$` |
 | `label`         | Human readable button label for this action. May be up to 256 characters long but should be as short as possible. |
 | `config`        | Configuration options for this Ticket Action. |
+| `attachments`   | If set (`{}`) for Ticket Actions of type `reply`, it's possible to attach files for the reply. At a later point you'll be able to specify a file schema to control what kind of attachments are allowed – for now there is no restriction an all checks should happen on the Integration's end. |
 
 #### `inbox.ticketActions[].config`
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -27,7 +27,7 @@ The test-request is a HTTP POST request to the specified URL, as are all WebHook
 
 The WebHook URL is required to support the HTTPS protocol with a valid SSL certificate to ensure all API communication is encryted. You can use [Let's Encrypt](https://letsencrypt.org/) to obtain free SSL certificates for your Integration.
 
-In order to remove a configured WebHook, simply send the same PATCH-request with an empty configuration object (`{ "webhook": {} }`).
+In order to remove a configured WebHook, simply send the same PATCH-request with null (`{ "webhook": null }`).
 
 ## Verification
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -515,6 +515,9 @@ definitions:
                       required:
                         - duration
                         - after
+                attachments:
+                  type: object
+                  description: 'When set allows attachments to be specified for a `reply` ticket action.'
           rightSidebar:
             type: array
             description: 'Configures the tabs available in the right sidebar after clicking on a Ticket within the Inbox.'


### PR DESCRIPTION
It's now possible that a Ticket Action of type `reply` may have attachments. To control whether it's possible to specify attachments for a Reply simply set `attachments: {}` on the Ticket Action definition in the [Manifest](general/manifest-api#request). At a later point you'll be able to specify a file schema to control what kind of attachments are allowed – for now there is no restriction an all checks should happen on the Integration's end.